### PR TITLE
Use HttpHeaderReader in RequestMessageReader and ResponseMessageReader

### DIFF
--- a/src/Bedrock.Framework.Experimental/Infrastructure/BufferExtensions.cs
+++ b/src/Bedrock.Framework.Experimental/Infrastructure/BufferExtensions.cs
@@ -42,6 +42,35 @@ namespace Bedrock.Framework.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool StartsWith(in this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> bytes)
+        {
+            if (sequence.Length < bytes.Length)
+            {
+                return false;
+            }
+
+            foreach (var segment in sequence)
+            {
+                if (bytes.Length <= segment.Length)
+                {
+                    return bytes.SequenceEqual(segment.Span[..bytes.Length]);
+                }
+                else if (!bytes[..segment.Length].SequenceEqual(segment.Span))
+                {
+                    return false;
+                }
+                bytes = bytes[segment.Length..];
+            }
+            ThrowUnreachable();
+            return false;
+
+            void ThrowUnreachable()
+            {
+                throw new InvalidOperationException("This location is thought to be unreachable");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void WriteNumeric<T>(ref this BufferWriter<T> buffer, uint number)
              where T : struct, IBufferWriter<byte>
         {


### PR DESCRIPTION
This is in order to test the Http1HeaderReader api.

In order to use it properly I had to change the API of the `RequestMessageReader` and `ResponseMessageReader` to return a `ParseResult<T>`. This leads to more verbose code, but that is natural when using error types in a language without good support for them. C# 9 should hopefully bring DUs which would make handling error cases less verbose.

Other than that, my biggest difficulty was merging an API which took a `ReadOnlySequence` with one that was tracking position via a `SequenceReader`. There is no API to advance a `SequenceReader` till a `SequencePosition`, so I had to remove usages of `SequenceReader`.

@davidfowl I'm interested in what you think?